### PR TITLE
change Target group name back

### DIFF
--- a/terraform/modules/ggroup-to-splunk/lambda.tf
+++ b/terraform/modules/ggroup-to-splunk/lambda.tf
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_event_rule" "send_ggroup_data_to_splunk_every_hour" {
   tags                = local.tags
 }
 
-resource "aws_cloudwatch_event_target" "send_ggroup_data_to_splunk_every_hour_tg" {
+resource "aws_cloudwatch_event_target" "send_ggroup_data_to_splunk_24_hours_tg" {
   rule = aws_cloudwatch_event_rule.send_ggroup_data_to_splunk_every_hour.name
   arn  = aws_lambda_function.send_ggroup_data_to_splunk.arn
 }


### PR DESCRIPTION
Target group name was changed back, as terraform would not apply corrctly when this was changed.