### PR TITLE
send cabinet office ggroup data to splunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,9 @@ terraform_plan_prod:
 
 terraform_apply_prod:
 	@cd terraform/deployments/prod; terraform init; terraform apply -auto-approve
+
+terraform_plan_prod_co:
+	@cd terraform/deployments/prod_co; terraform init; terraform plan
+
+terraform_apply_prod_co:
+	@cd terraform/deployments/prod_co; terraform init; terraform apply -auto-approve

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -52,7 +52,7 @@ jobs:
     plan:
       - *every-weekday
       - get: ggroup-data-to-splunk-git
-      - task: contractitest
+      - task: contract-test
         config:
           inputs:
           - name: ggroup-data-to-splunk-git

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -211,7 +211,7 @@ jobs:
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to deploy Ggroup data to splunk failed to deploy to prod."
+            message: "Failed to deploy Ggroup data to splunk failed to prod."
             health: unhealthy
 
   - name: ggroup-data-to-splunk-prod-co-deploy
@@ -250,10 +250,10 @@ jobs:
         on_success:
           <<: *health_status_notify
           params:
-            message: "Ggroup data to splunk prod co deployed successfully."
+            message: "Ggroup data to splunk prod CO deployed successfully."
             health: healthy
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to deploy Ggroup data to splunk failed to deploy to prod co."
+            message: "Failed to deploy Ggroup data to splunk failed to prod for CO."
             health: unhealthy

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -48,11 +48,11 @@ blocks:
     get: every-weekday-resource
     trigger: true
 jobs:
-  - name: google_contract_tests
+  - name: google-contract-tests
     plan:
       - *every-weekday
       - get: ggroup-data-to-splunk-git
-      - task: contract_test
+      - task: contractitest
         config:
           inputs:
           - name: ggroup-data-to-splunk-git
@@ -87,7 +87,7 @@ jobs:
             message: "Ggroup data to splunk contract tests failed."
             health: unhealthy
 
-  - name: code_validation
+  - name: code-validation
     serial: false
     plan:
       - get: ggroup-data-to-splunk-git
@@ -126,12 +126,13 @@ jobs:
             message: "Ggroup data to splunk validation failed"
             health: unhealthy
 
-  - name: ggroup_data_to_splunk_dev_deploy
+  - name: ggroup-data-to-splunk-dev-deploy
     serial: true
     plan:
       - get: ggroup-data-to-splunk-git
-        passed: [code_validation]
-      - task: terraform_deploy
+        trigger: true
+        passed: [code-validation]
+      - task: terraform-deploy
         config:
           inputs:
           - name: ggroup-data-to-splunk-git
@@ -166,15 +167,16 @@ jobs:
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to deploy Ggroup data to splunk validation failed dev."
+            message: "Failed to deploy Ggroup data to splunk failed dev deploy."
             health: unhealthy
 
-  - name: ggroup_data_to_splunk_prod_deploy
+  - name: ggroup-data-to-splunk-prod-deploy
     serial: true
     plan:
       - get: ggroup-data-to-splunk-git
-        passed: [ggroup_data_to_splunk_dev_deploy]
-      - task: terraform_prod_deploy
+        trigger: true
+        passed: [ggroup-data-to-splunk-dev-deploy]
+      - task: terraform-prod-deploy
         config:
           inputs:
           - name: ggroup-data-to-splunk-git
@@ -204,10 +206,54 @@ jobs:
         on_success:
           <<: *health_status_notify
           params:
-            message: "Ggroup data to splunk validation dev deployed successfully."
+            message: "Ggroup data to splunk prod deployed successfully."
             health: healthy
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to deploy Ggroup data to splunk validation failed dev."
+            message: "Failed to deploy Ggroup data to splunk failed to deploy to prod."
+            health: unhealthy
+
+  - name: ggroup-data-to-splunk-prod-co-deploy
+    serial: true
+    plan:
+      - get: ggroup-data-to-splunk-git
+        trigger: true
+        passed: [ggroup-data-to-splunk-dev-deploy]
+      - task: terraform-prod-co-deploy
+        config:
+          inputs:
+          - name: ggroup-data-to-splunk-git
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: gdscyber/cyber-security-concourse-base-image
+              username: ((docker_hub_username))
+              password: ((docker_hub_password))
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::779799343306:role/ggroup_data_to_splunk_concourse_role' 'eu-west-2'
+                  
+                pip install pipenv
+                cd ggroup-data-to-splunk-git/lambda
+                pipenv --python 3.7
+                pipenv install
+                
+                cd ..
+                export AWS_DEFAULT_REGION=eu-west-2
+                make zip
+                make terraform_apply_prod_co
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Ggroup data to splunk prod co deployed successfully."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Failed to deploy Ggroup data to splunk failed to deploy to prod co."
             health: unhealthy

--- a/terraform/deployments/prod_co/backend.tf
+++ b/terraform/deployments/prod_co/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "gds-security-terraform"
+    key     = "terraform/state/account/779799343306/service/ggroup-data-to-splunk-co.tfstate"
+    region  = "eu-west-2"
+    encrypt = true
+  }
+}

--- a/terraform/deployments/prod_co/main.tf
+++ b/terraform/deployments/prod_co/main.tf
@@ -1,0 +1,11 @@
+module "ggroup-to-splunk-prod-co" {
+  source              = "../../modules/ggroup-to-splunk"
+  environment         = "production"
+  lambda_zip_location = "../../../get_data_for_google_groups.zip"
+  runtime             = "python3.7"
+  lambda_memory       = 256
+  lambda_role_name    = "ggroup_lambda_exec_role"
+  lambda_timeout      = 900
+  credentials_prefix  = "/cabinetoffice.gov.uk"
+  suffix              = "_co"
+}

--- a/terraform/deployments/prod_co/provider.tf
+++ b/terraform/deployments/prod_co/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/terraform/modules/ggroup-to-splunk/cloudwatch.tf
+++ b/terraform/modules/ggroup-to-splunk/cloudwatch.tf
@@ -7,6 +7,6 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
 }
 
 resource "aws_cloudwatch_log_group" "send_ggroup_data_to_splunk" {
-  name = "/aws/lambda/${aws_lambda_function.send_ggroup_data_to_splunk.function_name}"
+  name = "/aws/lambda/${aws_lambda_function.send_ggroup_data_to_splunk.function_name}${var.suffix}"
   tags = local.tags
 }

--- a/terraform/modules/ggroup-to-splunk/lambda.tf
+++ b/terraform/modules/ggroup-to-splunk/lambda.tf
@@ -1,23 +1,7 @@
-data "aws_ssm_parameter" "google_credentials" {
-  name = "/google_data_to_splunk/credentials"
-}
-
-data "aws_ssm_parameter" "subject_email" {
-  name = "/google_data_to_splunk/subject_email"
-}
-
-data "aws_ssm_parameter" "groups_scope" {
-  name = "/google_data_to_splunk/groups_scope"
-}
-
-data "aws_ssm_parameter" "admin_readonly_scope" {
-  name = "/google_data_to_splunk/admin_readonly_scope"
-}
-
 resource "aws_lambda_function" "send_ggroup_data_to_splunk" {
   filename         = var.lambda_zip_location
   source_code_hash = filebase64sha256(var.lambda_zip_location)
-  function_name    = "send_ggroup_data_to_splunk"
+  function_name    = "send_ggroup_data_to_splunk${var.suffix}"
   role             = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.lambda_role_name}"
   handler          = "lambda_function.main"
   runtime          = var.runtime
@@ -26,7 +10,7 @@ resource "aws_lambda_function" "send_ggroup_data_to_splunk" {
 
   environment {
     variables = {
-      CREDENTIALS  = "/google_data_to_splunk/credentials"
+      CREDENTIALS  = "${var.credentials_prefix}/google_data_to_splunk/credentials"
       SUBJECT      = "/google_data_to_splunk/subject_email"
       ADMIN_SCOPE  = "/google_data_to_splunk/admin_readonly_scope"
       GROUPS_SCOPE = "/google_data_to_splunk/groups_scope"

--- a/terraform/modules/ggroup-to-splunk/variables.tf
+++ b/terraform/modules/ggroup-to-splunk/variables.tf
@@ -25,7 +25,6 @@ variable "lambda_role_name" {
   type = string
 }
 
-
 variable "credentials_prefix" {
   type    = string
   default = ""

--- a/terraform/modules/ggroup-to-splunk/variables.tf
+++ b/terraform/modules/ggroup-to-splunk/variables.tf
@@ -24,3 +24,14 @@ variable "environment" {
 variable "lambda_role_name" {
   type = string
 }
+
+
+variable "credentials_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "suffix" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
this pr:
- adds a deploy co job to the concourse pipeline
- adds a new terraform deployment for cabinet office
- passes in a suffix to differentiate cabinet office terraform


also as a fly by:
- change underscores in pipeline to hyphens

relates #23