### PR TITLE
add scopes to file, rather than getting them from ssm

### DIFF
--- a/lambda/contract_test.py
+++ b/lambda/contract_test.py
@@ -1,15 +1,10 @@
-from script import (
-    create_google_client,
-    get_credentials_file,
-    get_scope,
-    get_subject_email,
-)
+from script import create_google_client, get_credentials_file, get_subject_email
 
 admin_google_client = create_google_client(
     "admin",
     "directory_v1",
     get_credentials_file("/google_data_to_splunk/credentials"),
-    get_scope("/google_data_to_splunk/admin_readonly_scope"),
+    "https://www.googleapis.com/auth/admin.directory.group.readonly",
     get_subject_email("/google_data_to_splunk/subject_email"),
 )
 
@@ -17,7 +12,7 @@ groups_google_client = create_google_client(
     "groupssettings",
     "v1",
     get_credentials_file("/google_data_to_splunk/credentials"),
-    get_scope("/google_data_to_splunk/groups_scope"),
+    "https://www.googleapis.com/auth/apps.groups.settings",
     get_subject_email("/google_data_to_splunk/subject_email"),
 )
 

--- a/lambda/script.py
+++ b/lambda/script.py
@@ -10,15 +10,6 @@ from googleapiclient.errors import HttpError  # type: ignore
 ssm_client = boto3.client("ssm")
 
 
-def get_scope(scope: str) -> List[str]:
-    """
-    Returns the scope from AWS SSM.
-    """
-    return [
-        ssm_client.get_parameter(Name=scope, WithDecryption=True)["Parameter"]["Value"]
-    ]
-
-
 def get_subject_email(subject: str) -> str:
     """
     Returns the subject email from AWS SSM.
@@ -48,7 +39,7 @@ def create_google_client(
     api: str,
     api_version: str,
     service_account_file: str,
-    scope: List[str],
+    scope: str,
     subject: str,
     pageToken: str = None,
 ):
@@ -56,7 +47,7 @@ def create_google_client(
     Returns a given client built from a google api and api version passed in .
     """
     credentials = service_account.Credentials.from_service_account_file(
-        service_account_file, scopes=scope, subject=subject,
+        service_account_file, scopes=[scope], subject=subject,
     )
 
     google_client = googleapiclient.discovery.build(
@@ -74,7 +65,7 @@ def build_group_dict(api: str, api_version: str, scope: str) -> Dict[str, str]:
         api,
         api_version,
         get_credentials_file(os.environ["CREDENTIALS"]),
-        get_scope(os.environ[scope]),
+        scope,
         get_subject_email(os.environ["SUBJECT"]),
     )
     group_ids = {}
@@ -118,7 +109,7 @@ def get_group_info(
         api,
         api_version,
         get_credentials_file(os.environ["CREDENTIALS"]),
-        get_scope(os.environ[scope]),
+        scope,
         get_subject_email(os.environ["SUBJECT"]),
     )
 
@@ -155,6 +146,9 @@ def print_group_info(
 
 
 def main(event: Dict, context: Dict):
+    groups_scope = "https://www.googleapis.com/auth/apps.groups.settings"
+    admin_scope = "https://www.googleapis.com/auth/admin.directory.group.readonly"
+
     print_group_info(
-        "groupssettings", "v1", "GROUPS_SCOPE", "admin", "directory_v1", "ADMIN_SCOPE"
+        "groupssettings", "v1", groups_scope, "admin", "directory_v1", admin_scope
     )

--- a/lambda/test_script.py
+++ b/lambda/test_script.py
@@ -9,18 +9,9 @@ from script import (
     build_group_dict,
     get_credentials_file,
     get_group_info,
-    get_scope,
     get_subject_email,
     print_group_info,
 )
-
-
-@patch("script.ssm_client.get_parameter")
-def test_get_scope(mock_get_ssm):
-    mock_get_ssm.return_value = {"Parameter": {"Value": "test_scope_value"}}
-    expected = ["test_scope_value"]
-    actual = get_scope("test_scope")
-    assert actual == expected
 
 
 @patch("script.ssm_client.get_parameter")
@@ -48,14 +39,10 @@ def test_get_credentials_file(mock_get_ssm):
 
 
 @patch("script.get_subject_email")
-@patch("script.get_scope")
 @patch("script.get_credentials_file")
 @patch("script.create_google_client")
 def test_build_group_dict(
-    mock_create_google_client,
-    mock_get_credentials_file,
-    mock_get_scope,
-    mock_get_subject_email,
+    mock_create_google_client, mock_get_credentials_file, mock_get_subject_email,
 ):
     class GoogleClientMockClass:
         def groups():
@@ -97,12 +84,10 @@ def test_build_group_dict(
     mock_get_credentials_file.return_value = (
         "./lambda/test_assetts/expected_credentials_file.json"
     )
-    mock_get_scope.return_value = {"Parameter": {"Value": "test_scope_value"}}
     mock_get_subject_email.return_value = {"Parameter": {"Value": "test_subject_email"}}
 
     os.environ["CREDENTIALS"] = "credentials_param"
     os.environ["SUBJECT"] = "subject_email_param"
-    os.environ["test_groups_scope"] = "test_groups_scope"
     os.environ["DOMAIN"] = "digital.cabinet-office.gov.uk"
 
     actual = build_group_dict("http://api.com", "v3", "test_groups_scope")
@@ -118,14 +103,10 @@ def test_build_group_dict(
 
 
 @patch("script.get_subject_email")
-@patch("script.get_scope")
 @patch("script.get_credentials_file")
 @patch("script.create_google_client")
 def test_get_group_info(
-    mock_create_google_client,
-    mock_get_credentials_file,
-    mock_get_scope,
-    mock_get_subject_email,
+    mock_create_google_client, mock_get_credentials_file, mock_get_subject_email,
 ):
     class GoogleClientMockClass:
         def groups():
@@ -165,12 +146,10 @@ def test_get_group_info(
     mock_get_credentials_file.return_value = (
         "./lambda/test_assetts/expected_credentials_file.json"
     )
-    mock_get_scope.return_value = {"Parameter": {"Value": "test_scope_value"}}
     mock_get_subject_email.return_value = {"Parameter": {"Value": "test_subject_email"}}
 
     os.environ["CREDENTIALS"] = "credentials_param"
     os.environ["SUBJECT"] = "subject_email_param"
-    os.environ["test_groups_scope"] = "test_groups_scope"
     os.environ["DOMAIN"] = "digital.cabinet-office.gov.uk"
 
     group_dict = {"group1": "group1@email.com", "group2": "group2@email.com"}

--- a/terraform/modules/ggroup-to-splunk/lambda.tf
+++ b/terraform/modules/ggroup-to-splunk/lambda.tf
@@ -10,11 +10,9 @@ resource "aws_lambda_function" "send_ggroup_data_to_splunk" {
 
   environment {
     variables = {
-      CREDENTIALS  = "${var.credentials_prefix}/google_data_to_splunk/credentials"
-      SUBJECT      = "${var.credentials_prefix}/google_data_to_splunk/subject_email"
-      ADMIN_SCOPE  = "/google_data_to_splunk/admin_readonly_scope"
-      GROUPS_SCOPE = "/google_data_to_splunk/groups_scope"
-      DOMAIN       = "${var.domain}"
+      CREDENTIALS = "${var.credentials_prefix}/google_data_to_splunk/credentials"
+      SUBJECT     = "${var.credentials_prefix}/google_data_to_splunk/subject_email"
+      DOMAIN      = "${var.domain}"
     }
   }
 


### PR DESCRIPTION
This PR:

- Moves the scopes from ssm to be stored in the file as variables (they're not sensitive and this makes things clearer)
- removes get_scope function
- updates the tests to reflect this
- removes the scopes ssm param env var from the terraform


relates #27 